### PR TITLE
added ability to run data collection for specified amount of minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Possible values are:
 
  - DeleteDefaultFolder - will cause the default \output folder to be deleted and recreated
  - NewCustomFolder  - will cause the creation of a new folder in the format *\output_ddMMyyhhmmss*. If a previous collection created an \output folder, then that folder will be preserved when NewCustomFolder option is used.
+ - ServerBasedFolder - will cause the creation of a new folder in the format *\output_ServerName_ddMMyyhhmmss*.
 
 ### DiagStartTime
 
@@ -248,6 +249,7 @@ Specify the time when you want SQL LogScout to start data collection in the futu
 ### DiagStopTime
 
 Specify the time when you want SQL LogScout to stop data collection in the future. If the time is older than or equal to current time, data collection stops immediately. Format to use is "yyyy-MM-dd hh:mm:ss" (in quotes). For example: "2020-10-27 19:26:00" or "07-07-2021" (if you want to specify a date in the past without regard for a time).
+If the DiagStopTime represents an integer number then the data collection will continue for the specified in DiagStopTime minutes. Note that this duration INCLUDES startup data collection, so add a few minutes for collection to be completed.
 
 ### InteractivePrompts
 
@@ -306,6 +308,12 @@ SQL_LogScout.cmd AlwaysOn "DbSrv" PromptForCustomDir NewCustomFolder "2000-01-01
 ```
 
 **Note:** All parameters are required if you need to specify the last parameter. For example, if you need to specify stop time, the 5 prior parameters have to be passed.
+
+Collect data for 15 minutes.
+
+```bash
+SQL_LogScout.cmd AlwaysOn "DbSrv" PromptForCustomDir NewCustomFolder "2000-01-01 19:26:00" "15"
+```
 
 ### E. Execute SQL LogScout with multiple scenarios and in Quiet mode
 
@@ -492,7 +500,7 @@ SQL LogScout can be scheduled as a task in Windows Task Scheduler. This allows y
 - **-SQLInstance** - this is the name of the SQL Server instance to connect to. Please provide correct name (for example: "MACHINE1\SQLINST1")
 - **-OutputPath** - you specify whether you want a custom output path by providing the path itself, or specify 'UsePresentDir' to use the current folder as a base under which an output folder will be created. This corresponds to `CustomOutputPath` in SQL LogScout [Parameters](#parameters). Do NOT use `PromptForCustomDir` for a scheduled task, because you have to present to accept this on the screen.
 - **-CmdTaskName** - this is the name of the task as it appears in Windows Task Scheduler. This is an optional parameter that allows you to create multiple scheduled tasks. If you pass a value which already exists, you will be prompted to overwrite or keep original task. Default value is "SQL LogScout Task".
-- **-DeleteFolderOrNew** - this controls the sub-folder name where the output data goes. Options for it are `DeleteDefaultFolder`, which causes the default \output folder to be deleted and recreated or `NewCustomFolder` which causes the creation of a new folder in the format \output_ddMMyyhhmmss. For more information see, `DeleteExistingOrCreateNew` in [Parameters](#parameters).
+- **-DeleteFolderOrNew** - this controls the sub-folder name where the output data goes. Options for it are `DeleteDefaultFolder`, which causes the default \output folder to be deleted and recreated; `NewCustomFolder` which causes the creation of a new folder in the format \output_ddMMyyhhmmss or `ServerBasedFolder` which causes the creation of a new folder in the format \output_SQLInstance_ddMMyyhhmmss. For more information see, `DeleteExistingOrCreateNew` in [Parameters](#parameters).
 - **-StartTime** - this is the start time of the scheduled task in Windows Task Scheduler. If the `-Once` parameter is used together with this, only a single execution will occur on the specified date and time. If `-Daily` parameter is used, then the task will execute daily on the specified hour. Valid format for this parameter is  "yyyy-MM-dd hh:mm:ss" (in quotes). For example: "2020-10-27 19:26:00"
 - **-DurationInMins** - this specifies how long, in minutes, the SQL LogScout will run before it stops. Specify an integer value for example "10". This will calculate the stop time for SQL LogScout and pass it as a parameter to `DiagStopTime`.
 - **-Once** - you can request the scheduled task to run a single time at the specified `-StartTime`. Use either this parameter or `-Daily` but not both.

--- a/SQL LogScout/Bin/CommonFunctions.psm1
+++ b/SQL LogScout/Bin/CommonFunctions.psm1
@@ -1,4 +1,4 @@
-
+$serverBasedFolder = $false
 #=======================================Start of \OUTPUT and \Internal directories and files Section
 function InitCriticalDirectories()
 {
@@ -132,10 +132,19 @@ function Set-OutputPath()
 function Set-NewOutputPath 
 {
     Write-LogDebug "inside" $MyInvocation.MyCommand
-    
+
+Write-Host ""
     try 
     {
-        [string] $new_output_folder_name = "_" + @(Get-Date -Format yyyyMMddTHHmmss) + "\"
+        [string] $new_output_folder_name = $null;
+	if($serverBasedFolder -eq $true)
+	{
+		$new_output_folder_name= "_" + $global:gServerName.Replace(".","_").Replace("\","_")+"_" + @(Get-Date -Format yyyyMMddTHHmmss) + "\"
+	}
+	else 
+	{ 
+		$new_output_folder_name= "_" + @(Get-Date -Format yyyyMMddTHHmmss) + "\"
+	}
         $global:output_folder = $global:output_folder.Substring(0, ($global:output_folder.Length-1)) + $new_output_folder_name        
     }
     catch
@@ -154,7 +163,7 @@ function Set-InternalPath()
     try 
     {
         #the \internal folder is subfolder of \output
-        $global:internal_output_folder =  ($global:output_folder  + "internal\")    
+       	$global:internal_output_folder =  ($global:output_folder  + "internal\")    
     }
     catch 
     {
@@ -228,6 +237,11 @@ function ReuseOrRecreateOutputFolder()
             if($Global:overrideExistingCheckBox.IsChecked) {$DeleteOrNew = "D"}
             else{$DeleteOrNew = "N"}
         }
+	elseif($global:gDeleteExistingOrCreateNew -eq "ServerBasedFolder")
+	{
+		$DeleteOrNew = "N"
+		$serverBasedFolder = $true
+	}
         elseif (Test-Path -Path $global:output_folder)  
         {
             if ([string]::IsNullOrWhiteSpace($global:gDeleteExistingOrCreateNew) )
@@ -254,7 +268,6 @@ function ReuseOrRecreateOutputFolder()
                 }
 
             }
-
             elseif ($global:gDeleteExistingOrCreateNew -in "DeleteDefaultFolder","NewCustomFolder") 
             {
                 Write-LogDebug "The DeleteExistingOrCreateNew parameter is $($global:gDeleteExistingOrCreateNew)" -DebugLogLevel 2

--- a/SQL LogScout/Bin/SQLLogScoutPs.ps1
+++ b/SQL LogScout/Bin/SQLLogScoutPs.ps1
@@ -49,7 +49,7 @@ param
     [string] $CustomOutputPath = "PromptForCustomDir",
 
     #scenario is an optional parameter since there is a menu that covers for it if not present
-    [Parameter(Position=4,HelpMessage='Choose DeleteDefaultFolder|NewCustomFolder')]
+    [Parameter(Position=4,HelpMessage='Choose DeleteDefaultFolder|NewCustomFolder|ServerBasedFolder')]
     [string] $DeleteExistingOrCreateNew = [String]::Empty,
 
     #specify start time for diagnostic
@@ -492,7 +492,7 @@ function ValidateParameters ()
     #validate DeleteExistingOrCreateNew parameter
     if ([String]::IsNullOrWhiteSpace($DeleteExistingOrCreateNew) -eq $false)
     {
-        $DelExistingOrCreateNewParamArr = @("DeleteDefaultFolder","NewCustomFolder")
+        $DelExistingOrCreateNewParamArr = @("DeleteDefaultFolder","NewCustomFolder","ServerBasedFolder")
         if($DeleteExistingOrCreateNew -inotin $DelExistingOrCreateNewParamArr)
         {
             Write-LogError "Parameter 'DeleteExistingOrCreateNew' can only accept one of these values: $DelExistingOrCreateNewParamArr. Current value '$DeleteExistingOrCreateNew' is incorrect."
@@ -526,6 +526,11 @@ function ValidateParameters ()
     if (($DiagStopTime -ne "0000") -and ($false -eq [String]::IsNullOrWhiteSpace($DiagStopTime)))
     {
         [DateTime] $dtStopOut = New-Object DateTime
+	[int]$durationInMinutes = 0;
+	if([int]::TryParse($DiagStopTime,[ref]$durationInMinutes))
+	{
+		$DiagStopTime = (Get-Date).AddMinutes($durationInMinutes)		
+	}
         if([DateTime]::TryParse($DiagStopTime, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::None, [ref]$dtStopOut) -eq $false)
         {
             Write-LogError "Parameter 'DiagStopTime' accepts DateTime values (e.g. `"2021-07-07 17:14:00`"). Current value '$DiagStopTime' is incorrect."

--- a/SQL LogScout/Bin/ScheduleSQLLogScoutAsTask.ps1
+++ b/SQL LogScout/Bin/ScheduleSQLLogScoutAsTask.ps1
@@ -382,7 +382,10 @@ try
     {    
         $DeleteFolderOrNew = 'NewCustomFolder'
     }
-
+    elseif ($DeleteFolderOrNew -ieq 'ServerBasedFolder')
+    {    
+        $DeleteFolderOrNew = 'ServerBasedFolder'
+    }
     else
     {
         Log-ScheduledTask -Message "ERROR: Please specify a valid parameter for DeleteFolderOrNew. Exiting..." -WriteToConsole $true -ConsoleMsgColor "Red"


### PR DESCRIPTION
Frequently it is more convenient to specify how long to run data collection than specifying the specific end time, especially when doing some automated monitoring.
It has added a new format for the DiagStartTime parameter. If it is an integer number, data collection should be run for DiagStartTime minutes.
I added the new option ServerBasedFolder to separate Output folders for different servers and make it possible to run several scouts simultaneously.
